### PR TITLE
fixed dependency issue in rubocop spec

### DIFF
--- a/spec/lint/rubocop_spec.rb
+++ b/spec/lint/rubocop_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'rubocop analysis' do
   it 'has no offenses' do


### PR DESCRIPTION
When trying to run initial rspec, was getting this error: 
```
An error occurred while loading ./spec/lint/rubocop_spec.rb.
Failure/Error: require 'spec_helper'

LoadError:
  cannot load such file -- spec_helper
```
This change resolves that issue.